### PR TITLE
Longest compound word solution

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,10 @@
+from command line:
+
+> git clone https://github.com/sashawam/quiz.git
+> cd quiz
+> go build -o lcw_search ./compword
+> ./lcw_search ./word.list
+
+or
+
+> ./lcw_search ./word.list parallel

--- a/compword/README.md
+++ b/compword/README.md
@@ -1,0 +1,88 @@
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+
+INPUT: a text file with one word per line<BR>
+OUTPUT: longest compound word consisting of words found in INPUT<BR>
+
+ASSUMPTIONS: <BR>
+	input file is a text file<BR> 
+	input file fits into memory<BR>
+	strings do not have to be ASCII<BR>
+	word list does not have to be alhabetically sorted<BR>
+	word list does not have to be unique<BR>
+	
+GOAL: minimize the search time for finding the longest compound word in the list
+	
+ALGORITHMIC APPROACH:<BR>
+	let's start with the longest word<BR>
+		the testing is accomplished by checking {prefix, suffix} pairs of the word<BR>
+			prefix is a substring of the word starting with 0 index and having a variable length<BR>
+			suffix is the remaining substring of the word with the starting index of length(prefix)<BR>
+			if both prefix and suffix are found in the word list or are compound words, then the word 
+			is a compound word<BR>
+	this approach requires reccursion<BR>
+		let's use sort.SearchStrings([]string, string) to determine if prefix/suffix is in the word list<BR>
+		SearchStrings(...) is quite expensive for large string arrays<BR>
+	
+	by utilizing additional data structures, we segment the words list and minimize the search space for 
+	each iteration; in other words:
+		the []string input to the sort.SearchStrings is based on the size of the substring being searched;
+		since the words are stored in buckets, we will search much smaller arrays during each iteration;
+		if a substring is not found in the list, we will store it in a lookup table (as a map[string]bool)	
+			and check that lookup table before a search
+	
+DATA STRUCTURES:<BR>
+	The idea is to reduce the search space at each iteration<BR>
+	input words are loaded into buckets defined as a map of string slices<BR>
+		a bucket is accessed via a unique compound key and contains an array of words of the same length<BR>
+			the unique compound key = {[first letter of a word], [word length]}<BR>
+			thus, all of the words with the same first letter and the same length are stored in the same sub-array<BR>
+	unique keys are stored in an array<BR>
+		the keys array is sorted by <word length> field<BR>
+	set of inValidWords implemented as a map[string]bool<BR>
+	
+JUSTIFICATION FOR ADDITIONAL DATA STRUCTURES:<BR>
+	Keys array is much smaller than the words list; for the test file:
+		we have 263533 records and 538 buckets
+	Time needed to create/sort the Keys array is negligable compared to loading the words into memory.
+	
+	Keys array is sorted by word size in descending order -- thus, the first compound word found is the 
+	longest one.
+		
+	Set of invalid words (words searched and not found in the words list) is maintained to avoid 
+	searching them repeatedly during reccursions. This structure can be kept to a certain size if 
+	needed at the expense of repeated searches;
+		- it could also be localized per bucket if using too much space.
+		- the search algorithm is 200x faster when using the invalidWords set.
+		
+	This approach finds the longest compound word in under 0.5 milliseconds on an Intel i7 2.2GH machine 
+	(for the sample data set; not counting the time to load the words into memory from the disk)
+
+OUTPUT EXAMPLE for the sample INPUT file of 263533 words:<BR>
+	Reading input file <local path>/word.list<BR>
+	Imported 263533 words<BR>
+	Loading the strings took  123.636619ms<BR>
+		Number of buckets =   538<BR>
+	(Sorting the key array took  46.609µs)<BR>
+		testing word: pneumonoultramicroscopicsilicovolcanoconiosis<BR>
+		testing word: dichlorodiphenyltrichloroethanes<BR>
+		testing word: dichlorodiphenyltrichloroethane<BR>
+		testing word: floccinaucinihilipilifications<BR>
+		testing word: antidisestablishmentarianisms<BR>
+	Longest compound word found: antidisestablishmentarianisms<BR>
+	Longest compound word size:  29<BR>
+	Elapsed:  374.702µs<BR>
+	Size of invalidWords Set is  174<BR>
+
+PARALLEL CODE:<BR>
+  uses a pool of initalized go routines; task requests are sent via 'input' channel<BR>
+  performance for the provided input file is not better than the serial version; this is <BR>
+  due to chan communcation overhead with the parallel version.
+  
+BUILD:<BR>
+	go build -o lcword_search ./compword<BR>
+	
+RUN:<BR>
+	./lcword_search <local path>/word.list<BR>
+	./lcword_search <local path>/word.list parallel<BR>

--- a/compword/io.go
+++ b/compword/io.go
@@ -1,0 +1,75 @@
+/*
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+
+// loadWords function is
+// using bufio.Scanner to load the words into memory from a text file
+// while the words are being loaded into buckets, the keys array is also being created
+*/
+
+package main
+/* load the words from a text file
+   store the words in buckets with a compound key of [first letter of the word, word size]
+   add each unique key to the keys array
+   once loaded, sort the keys array by the length of the word
+*/
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+	//"time"
+	"fmt"
+)
+
+func loadWords(path string) error {
+	var word string
+	var key Key
+	
+	fmt.Println("Reading input file " + path)
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	defer f.Close()
+	
+	//var start time.Time
+	size := 0;
+	
+	// initialize the words and keys structures, 
+	// segment the words into buckets by first character/rune and the length of the string
+	
+	
+	//addKeysDuration := time.Duration(0)
+    //addWordsDuration := time.Duration(0)
+	
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+		
+	for scanner.Scan() {
+		size++
+		word = strings.ToLower(scanner.Text())
+		key = Key{rune(word[0]), len(word)}
+		
+		//start = time.Now();
+		// add unique key to the Keys array
+		keys.AddKey(key)
+		//addKeysDuration += time.Now().Sub(start)
+		
+		//start = time.Now();
+		// append the word to the bucket
+		words[key] = append(words[key], word) 
+		//addWordsDuration += time.Now().Sub(start)
+		
+	}
+
+	fmt.Println("Imported " + strconv.Itoa(size) + " words")
+	//fmt.Println("add keys duration  = ", addKeysDuration)
+	//fmt.Println("add words duration = ", addWordsDuration)
+	
+	return scanner.Err()
+}
+

--- a/compword/key.go
+++ b/compword/key.go
@@ -1,0 +1,33 @@
+/*
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+*/
+package main
+
+// structure to save and sort compound map keys by word length
+type Key struct {
+	key rune
+	size int
+}
+
+// array of keys
+type SortedBySizeKeys []Key
+
+// sorting functions
+func (s SortedBySizeKeys) Len() int {
+    return len(s)
+}
+func (s SortedBySizeKeys) Swap(i, j int) {
+    s[i], s[j] = s[j], s[i]
+}
+func (s SortedBySizeKeys) Less(i, j int) bool {
+    return /*s[i].key < s[j].key &&*/ s[i].size > s[j].size
+}
+
+// adding a unique key utilizes the keysMap set
+func (s * SortedBySizeKeys) AddKey(key Key) {
+	if _, ok := keysMap[key]; ok { return }
+	keysMap[key] = true;
+	*s = append(*s, key)
+}

--- a/compword/main.go
+++ b/compword/main.go
@@ -1,0 +1,153 @@
+/*
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+
+INPUT: a text file with one word per line
+OUTPUT: longest compound word consisting of words found in INPUT
+
+ASSUMPTIONS: 
+	input file is a text file 
+	input file fits into memory
+	strings do not have to be ASCII
+	word list does not have to be alhabetically sorted
+	word list does not have to be unique
+	
+GOAL: minimize the search time for finding the longest compound word in the list
+	
+ALGORITHMIC APPROACH:
+	each word from INPUT needs to be tested for being a compound word,
+	let's start with the longest word
+			the testing is accomplished by checking {prefix, suffix} pairs of the word
+				prefix is a substring of the word starting with 0 index and having a variable length	
+				suffix is the remaining substring of the word with the starting index of length(prefix)
+			if both prefix and suffix are found in the word list or are compound words, then the word is a compound word
+				this approach requires reccursion
+			let's use sort.SearchStrings([]string, string) to determine if prefix/suffix is in the word list
+			SearchStrings(...) is quite expensive for large string arrays
+	
+	by utilizing additional data structures, we segment the words list and minimize the search space for each iteration; 
+	in other words,
+		the []string input to the sort.SearchStrings will be based on the size of the substring being searched;
+		since the words are stored in buckets, we will search much smaller arrays during each iteration;
+		if a substring is not found in the list, we will store it in a lookup table (as a map[string]bool)	
+			and check that lookup table before a search
+	
+DATA STRUCTURES:
+	The idea is to reduce the search space at each iteration
+	input words are loaded into buckets defined as a map of string slices
+		a bucket is accessed via a unique compound key and contains an array of words of the same length
+			the unique compound key = {<first letter of a word>, <word length>}
+			thus, all of the words with the same first letter and the same length are stored in the same sub-array
+	unique keys are stored in an array
+		the keys array is sorted by <word length> field
+	set of inValidWords implemented as a map[string]bool; 
+	
+JUSTIFICATION FOR ADDITIONAL DATA STRUCTURES:
+	Keys array is much smaller than the words list; for the test file, we have 263533 records and 538 buckets
+	Time needed to create the Keys array and to sort it is negligable compared to loading the words into memory
+	
+	Keys array is sorted by word size in descending order -- thus, the first compound word found is the longest one
+		
+	Set of invalid words (words searched and not found in the words list) is maintained to avoid searching them repeatedly
+		during reccursions. This structure can be kept to a certain size if needed at the expense of repeated searches;
+		It could also be localized per bucket if using too much space.
+		The search algorithm is 200x faster when using the invalidWords set
+		
+	This approach finds the longest compound word in under 0.5 milliseconds 
+	on an Intel i7 2.2GH machine (for the sample data set; not counting the time to load the words into memory from the disk)
+
+OUTPUT EXAMPLE for the sample INPUT file of 263533 words:
+	Reading input file <local path>/wordlist.txt
+	Imported 263533 words
+	Loading the strings took  123.636619ms
+		Number of buckets =   538
+	(Sorting the key array took  46.609µs)
+		testing word: pneumonoultramicroscopicsilicovolcanoconiosis
+		testing word: dichlorodiphenyltrichloroethanes
+		testing word: dichlorodiphenyltrichloroethane
+		testing word: floccinaucinihilipilifications
+		testing word: antidisestablishmentarianisms
+	Longest compound word found: antidisestablishmentarianisms
+	Longest compound word size:  29
+	Elapsed:  374.702µs
+	Size of invalidWords Set is  174
+		
+BUILD:
+	go build -o words ./compwords
+	
+RUN:
+	./words <local path>/wordlist.txt	 	
+*/
+package main
+
+import (
+	"os"
+	"sort"
+	"time"
+	"fmt"
+	//"runtime"
+)
+
+type MyMapList map[Key][]string	// buckets of words with the same first letter and same length
+
+var keysMap map[Key]bool 			// used to speed up the loading of the keys array
+var keys SortedBySizeKeys			// see key.go source file for details
+
+var words MyMapList
+var minWordLength int				// there is no need to look for one letter words if they do not exist in the INPUT
+	
+func main() {
+	
+	// check the program args
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: ./words <filename>")
+		fmt.Println("		./words <filename> parallel")
+		return
+	}
+    parallel := false
+	if len(os.Args) == 3 {
+		parallel = true
+	}
+	
+	start := time.Now()
+	
+	keysMap = make(map[Key]bool) // helps with loading keys
+	keys = make(SortedBySizeKeys, 0)
+	words = make(MyMapList)
+	// load the words into the map
+    err := loadWords(os.Args[1])	
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	keysMap = nil // not needed any longer
+	fmt.Println("loading the strings took ", time.Now().Sub(start));
+	fmt.Println("number of buckets =  ",  len(keys));
+	
+	// sort the keys array by length, so we start search the longest words first
+	sort.Sort(keys)
+	minWordLength = keys[len(keys) - 1].size
+	// end sort keys array
+
+
+	// the keys array is already sorted by word size in descending order, longest first
+	// we now start looking into each word from the map by sorted keys, the first word to satisfy the conditions is the answer
+	// in other words, 
+	//		we look at the longest bucket first,
+	// 		and for each word in the bucket, test if it is a compound word;
+	// 		since we are already sorted by size, there is no need to chek if it is the longest compound word
+	
+	start = time.Now()
+	var resultString string
+	
+	if parallel {
+		resultString = parallelSearch(6, words, keys)
+	} else {
+		resultString = search()
+	}
+											
+	fmt.Println("Total Elapsed Time: ", time.Now().Sub(start))
+	fmt.Println("Longest compound word found: " + resultString)
+	fmt.Println("Longest compound word size: ", len(resultString))	
+}

--- a/compword/parallelSearch.go
+++ b/compword/parallelSearch.go
@@ -1,0 +1,118 @@
+/* 
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+
+concurrent code with worker pool and task generator for compound word search
+
+parallelSearch(...)
+taskGenerator(...)
+worker(...)
+
+*/
+package main
+
+import (
+	"time"
+	"fmt"
+)
+
+// using a goroutine pool and sending task requests via an input channel
+// signaling the end of work is done via 'quit' channel
+// we block waiting for the first word to be returned from the workers
+// the 'result' channel is buffered to ensure we do not deadlook
+// the taskGenerator sends buckets' indexes via 'input' channel; thus, each worker is assigned a unique bucket
+func parallelSearch(numProcessors int, words MyMapList, keys SortedBySizeKeys) string {
+	
+	fmt.Println("Running in parallel with ", numProcessors, " logical CPUs...")
+	
+	var result = make (chan string, 3 * numProcessors) // make channel for returning the result, buffer it***
+	// *** we can have additional goroutines return results as we are shutting down
+	//		thus, to avoid a deadlock, we will allow enough space in the channel for all goroutines to potentially return results
+	var input = make (chan int, numProcessors) // make channel for inputing data into worker threads
+	var quit = make (chan bool) // signal goroutine completion
+	var quitSendData = make (chan bool) // signal goroutine completion
+	
+	inValidWords := make(map[string]bool)
+	// set the worker goroutines, one per processor
+	for j := 0; j< numProcessors; j++ {
+		go worker(&inValidWords, j, input, result, quit)
+	}
+	
+	start := time.Now()
+	// call the workers
+	go taskGenerator(len(keys), numProcessors, input, result, quitSendData)
+
+	// block until the first result comes in
+	resultString := <-result
+	
+	fmt.Println("Longest word found in ", time.Now().Sub(start))
+	
+	// notify the task generator to stop
+	quitSendData <- true
+	
+	// notify all worker goroutines to stop	
+	for j := 0; j< numProcessors; j++ {
+		quit <- true
+	}
+			
+	return resultString
+}
+
+// test buckets in parallel by sending bucket id to a worker goroutine via input channel
+func taskGenerator(keysArrayLen int, numProcessors int, in chan int, result chan string, quitdata chan bool ) {
+	for i := 0; i < keysArrayLen; i = i + numProcessors {
+		select {
+			case <- quitdata: {
+				fmt.Println("Done sending data to workers.")
+				return
+			}
+			default:
+				for j := 0; j< numProcessors; j++ {
+					in <- i + j // send request to goroutine
+				}
+		}
+		time.Sleep(time.Microsecond * 1)
+	}
+	
+	// if nothing found, return an empty string so the program can terminate
+	result <- ""
+}
+
+// this is where the search is taking place
+// each worker maintains its own copy of the invalidWords set
+// result channel is used only if the worker found a compound word
+// it blocks on in and quit channels
+func worker(invalidWords * map[string]bool, wid int, in <-chan int, result chan<- string, quit <-chan bool ) {
+	//invalidWords := make(map[string]bool)
+
+	threadid := wid
+	//fmt.Println("Worker goroutine created: ", threadid)
+	
+	start := time.Now()
+	for {
+		select {
+			case <- quit: {
+				// finish goroutine
+				//fmt.Println("Worker goroutine ", threadid, " finished. Elapsed time ", time.Now().Sub(start))
+				//invalidWords = nil
+				return
+			}
+			case i := <- in: {	
+				//start := time.Now()			
+				//if i < len(keys) {
+					for wordListIndex := range words[keys[i]] {
+						word := words[keys[i]][wordListIndex]
+						 
+						fmt.Println("\t\tWorker goroutine ", threadid, " testing word: ", word)
+						if _, found := (*invalidWords)[word]; !found && isCompoundWord(word, invalidWords) {
+							fmt.Println("Longest word found in ", time.Now().Sub(start), " word is ", word)
+							result <- word 
+							break
+						} 
+					}
+			}
+		}
+		time.Sleep(time.Microsecond * 1)
+	}	
+}

--- a/compword/search.go
+++ b/compword/search.go
@@ -1,0 +1,77 @@
+/*
+Longest Compound Word Finder 
+created by Aleksandar Slavkovic on Jan 26, 2016
+email: sashawam@gmail.com
+
+search() and isCompoundWord(...)  functions
+*/
+package main
+
+import (
+	"sort"
+	"fmt"
+	"time"
+)
+
+// search for the first compound word
+func search() string {
+	inValidWords := make(map[string]bool)
+	start := time.Now()
+	for i := range keys {
+		for wordListIndex := range words[keys[i]] {
+			word := words[keys[i]][wordListIndex]
+
+			if _, ok := inValidWords[word]; !ok && isCompoundWord(word, &inValidWords) {
+				fmt.Println("Longest word found in ", time.Now().Sub(start))
+				fmt.Println("Size of invalid word set: ", len(inValidWords))
+				inValidWords = nil
+				return word
+			}
+		}
+	}
+
+	fmt.Println("Size of invalid word set: ", len(inValidWords))
+	inValidWords = nil
+	return ""
+}
+
+// test if a word is a compound word
+func isCompoundWord(word string, invalidWords * map[string]bool) bool {
+
+	length := len(word)
+		
+	for i:= length - minWordLength; i > minWordLength; i-- {
+		substr := word[0:i]
+		
+		if _, ok := (*invalidWords)[substr]; ok {  continue } // we tested this, it does not exist
+		
+		key := Key{rune(substr[0]), len(substr)}
+		bucketLen := len(words[key])
+		if bucketLen == 0 { continue } // there is no such a bucket
+		
+		index := sort.SearchStrings(words[key], substr) // search the prefix in the bucket
+		if index < bucketLen && words[key][index] == substr || isCompoundWord(substr, invalidWords) {
+			// the prefix exists in the bucket or is a compound word
+			// now check the remainder/suffix
+			substr = word[i:]
+			
+			if _, ok := (*invalidWords)[substr]; ok {  continue } // we tested this, it does not exist
+			 
+			key = Key{rune(substr[0]), len(substr)}
+			bucketLen = len(words[key])
+			if  bucketLen == 0 { continue } // not found
+			
+			index = sort.SearchStrings(words[key], substr) // search the prefix in the bucket
+			if index < bucketLen && words[key][index] == substr || isCompoundWord(substr, invalidWords) {
+				return true
+			} else {
+				(*invalidWords)[substr] = true
+			}
+		} else {
+			(*invalidWords)[substr] = true
+		}
+		// else the word does not exist, this is invalid, continue to the next length substring
+	}
+
+	return false;
+}


### PR DESCRIPTION
This solution buckets the words by first letter and word size, and during the search it uses another set (map[string]bool) structure to track invalid/missing words to speed up the search. It also starts the search from the "longest" bucket, and thus does not require keeping track of the (longest word) result, since the first compound word to be found is also the longest one.

Non-parallel search returns the result in under 0.5 ms for the sample file on Intel i7 2.2 Gh machine.

Parallel search uses a pool of go routines, with another go routine sending search requests to the pool via 'input' channel... it is slightly slower than the non-parallel search, at 0.6 ms for the same file. 

I only did a cursory scan of existing solutions, so my apologies if something similar has already been submitted.